### PR TITLE
fix "Undefined offset" php notice

### DIFF
--- a/src/GravityForms.php
+++ b/src/GravityForms.php
@@ -53,7 +53,9 @@ class GravityForms
             foreach ($entries as $entry) {
 
                 foreach ($fields as $field) {
-                    $data[$title][$field['label']] = $entry[$field['id']];
+                    if (!empty($entry[$field['id']])) {
+                        $data[$title][$field['label']] = $entry[$field['id']];
+                    }
                 }
 
                 $data[$title]['date']       = $entry['date_created'];


### PR DESCRIPTION
I just turned WP_DEBUG on and got this php notice:

( ! ) Notice: Undefined offset: 5 in /home/xxxxxx/HTTPdocs/xxxxxx-wp/www/wp-content/plugins/gdpr-for-gravity-forms/src/GravityForms.php on line 56
--
1 | 0.0002 | 415960 | {main}( ) | .../tools.php:0
2 | 0.0005 | 463688 | require_once( '/home/xxxxxx/Work/wordpress/wp-admin/admin.php' ) | .../tools.php:10
3 | 0.3221 | 39078984 | do_action( ) | .../admin.php:224
4 | 0.3221 | 39079360 | WP_Hook->do_action( ) | .../plugin.php:453
5 | 0.3221 | 39079360 | WP_Hook->apply_filters( ) | .../class-wp-hook.php:310
6 | 0.3221 | 39080488 | Codelight\GDPR\Admin\WordpressAdminPage->renderPage( ) | .../class-wp-hook.php:286
7 | 0.3224 | 39083256 | Codelight\GDPR\DataSubject\AdminTabDataSubject->renderContents( ) | .../WordpressAdminPage.php:44
8 | 0.3225 | 39099872 | do_settings_sections( ) | .../AdminTab.php:102
9 | 0.3225 | 39099872 | Codelight\GDPR\DataSubject\AdminTabDataSubject->renderTab( ) | .../template.php:1332
10 | 0.3238 | 39146632 | Codelight\GDPR\DataSubject\AdminTabDataSubject->getRenderedResults( ) | .../AdminTabDataSubject.php:49
11 | 0.3238 | 39146632 | Codelight\GDPR\DataSubject\DataSubject->hasData( ) | .../AdminTabDataSubject.php:63
12 | 0.3238 | 39146632 | Codelight\GDPR\DataSubject\DataSubject->getData( ) | .../DataSubject.php:140
13 | 0.3238 | 39146632 | Codelight\GDPR\DataSubject\DataRepository->getData( ) | .../DataSubject.php:151
14 | 0.3238 | 39146632 | apply_filters( ) | .../DataRepository.php:27
15 | 0.3238 | 39147032 | WP_Hook->apply_filters( ) | .../plugin.php:203
16 | 0.3251 | 39151440 | Codelight\GDPR\Modules\GravityForms\GravityForms->getExportData( ) | .../class-wp-hook.php:286

I was able to fix this by setting a check for an entry field.